### PR TITLE
Adding DALI examples vocabulary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,7 @@ recommended to work like this:
 (9) Unmount the vocabulary repo: ``fusermount -u ivoa-repo``.
 (10) Update https://wiki.ivoa.net/twiki/bin/view/IVOA/VEPs as
      appropriate.
-
+(11) Run the validator from vocino2/validator on the new vocabulary:
+     ``../vocinvo/validator/vocvalidator.py http://www.ivoa.net/rdf/...``
 
 (Markus has a script rebuild.sh that does steps (6)-(9))

--- a/examples/terms.csv
+++ b/examples/terms.csv
@@ -1,0 +1,8 @@
+name;1;Example Name;A short title of the example, suitable for display in space-limited labels.;
+capabilitiy;1;Complies with;The IVOID of the standard that the example is written against.;
+generic-parameter;1;Parameter;A parameter to pass to the service to reproduce the example.  The object of such a triple must have one triple each with a #key and #value property (that's the keyval type that should be defined here but is not yet).;
+key;1;Parameter Key;The name of a parameter to pass into a service.  The subject of a triple with #key should also have exactly one triple with a #value property;
+value;1;Parameter Value;The value of a parameter to pass into a service, serialised into a string. The subject of a triple with #value should also have exactly one triple with a #key property;
+continuation;1;More Examples;(The URL of) another document with examples for the service the current examples document talks about.;
+query;1;TAP Query String;A query for a TAP service, currently always written in ADQL (defined in TAP).;
+table;1;Table Queried;A table used by this example's query (defined in TAP).;

--- a/vocabs.conf
+++ b/vocabs.conf
@@ -142,3 +142,15 @@ description: A vocabulary of types of astronomical objects, ranging from
   intended for use in Obscore's target_class and similar fields.
 draft: True
 authors: Simbad
+
+[examples]
+flavour: RDF Property
+timestamp: 2023-01-19
+title:DALI Examples
+description: A vocabulary for expressing examples for the use of protocols.
+  It contains concepts such as which parameters to pass to services or
+  the standards implemented by it.  Its main use is in RDFa documents
+  described by section 2.3 of the DALI specification, 
+  <https://ivoa.net/documents/DALI/>.
+draft: True
+authors: Dowler, P.; Demleitner, M.; Taylor, M.; Tody, D.


### PR DESCRIPTION
This vocabulary was actually announced in DALI 1.1, but back then the infrastructure for vocabularies was still only rudimentary.  Now that we have it, we ought to make good on the promise.

We also have the two extra terms from TAP in here.