### PR TITLE
Fixing typo on capability.

### DIFF
--- a/examples/terms.csv
+++ b/examples/terms.csv
@@ -1,8 +1,8 @@
 name;1;Example Name;A short title of the example, suitable for display in space-limited labels.;
-capabilitiy;1;Complies with;The IVOID of the standard that the example is written against.;
+capability;1;Complies with;The IVOID of the standard that the example is written against.;
 generic-parameter;1;Parameter;A parameter to pass to the service to reproduce the example.  The object of such a triple must have one triple each with a #key and #value property (that's the keyval type that should be defined here but is not yet).;
-key;1;Parameter Key;The name of a parameter to pass into a service.  The subject of a triple with #key should also have exactly one triple with a #value property;
-value;1;Parameter Value;The value of a parameter to pass into a service, serialised into a string. The subject of a triple with #value should also have exactly one triple with a #key property;
-continuation;1;More Examples;(The URL of) another document with examples for the service the current examples document talks about.;
+key;1;Parameter Key;The name of a parameter to pass into a service.  The subject of a triple with #key should also have exactly one triple with a #value property.;
+value;1;Parameter Value;The value of a parameter to pass into a service, serialised into a string. The subject of a triple with #value should also have exactly one triple with a #key property.;
+continuation;1;More Examples;(The URL of) another document with examples for the service the current examples document talks about.  The URL can be relative to the location of the current document.;
 query;1;TAP Query String;A query for a TAP service, currently always written in ADQL (defined in TAP).;
 table;1;Table Queried;A table used by this example's query (defined in TAP).;


### PR DESCRIPTION
This is after a review by Mark, who also suggested the clarification that continuation URIs can be relative that's also in here.