### PR TITLE
Have concept urls more accessible in HTML renderings

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -256,6 +256,18 @@ input.popup-control {
     padding: 0.5rem;
     font-size: 80%;
 }
+
+/* to a bit lighter with link underlines: we have a high link density
+in our documents (and I don't care if this is a no-op on old browsers */
+td a {
+    text-decoration-color: transparent;
+}
+
+td a:hover {
+    text-decoration-color: currentcolor;
+    transition: all 0.2s ease-in;
+}
+
 """
 
 
@@ -664,6 +676,11 @@ class Term(object):
                     #... and the property only has blank nodes as objects
                     yield T.span(class_="proplabel")[label]
 
+    def get_url(self):
+        """returns this term's full RDF URI.
+        """
+        return self.vocabulary.baseuri+"#"+self.term
+
     def as_html(self):
         """returns elementtree for an HTML table line for this term.
         """
@@ -686,9 +703,11 @@ class Term(object):
             append_with_sep(parents, self._format_term_as_html(name), ", ")
 
         el =  T.tr(class_=row_class, id=self.term)[
-            T.td(class_="term")[self.term
-                +(" (Preliminary)" if preliminary else "")
-                +(" (Deprecated)" if deprecated else "")],
+            T.td(class_="term")[
+                T.a(title="Copy the link URL for this term's RDF URI",
+                    href=self.get_url())[self.term],
+                " (Preliminary)" if preliminary else "",
+                " (Deprecated)" if deprecated else ""],
             T.td(class_="label")[self.label],
             T.td(class_="description")[self.description],
             T.td(class_="parent")[parents],

--- a/convert.py
+++ b/convert.py
@@ -123,23 +123,6 @@ dc:description a owl:AnnotationProperty.
 
 
 JAVASCRIPT = """
-current_highlight = null;
-
-function highlight_fragment(ev) {
-	var parts = document.URL.split("#");
-	if (parts.length==2) {
-	  if (current_highlight) {
-		  var oldEl = document.getElementById(current_highlight);
-		  oldEl.setAttribute("style", "");
-		}
-		current_highlight = parts[parts.length-1];
-		var el = document.getElementById(current_highlight);
-		el.setAttribute("style", "border: 2pt solid yellow");
-	}
-}
-
-window.addEventListener("load", highlight_fragment);
-window.addEventListener("hashchange", highlight_fragment);
 """
 
 CSS_STYLE = """


### PR DESCRIPTION
We now have copyable concept URIs under the terms.

People too often copy the URI of a term on one of ourHTML pages, and it
should be a bit easier to do the right thing, i.e., copy the unversioned URI.

Whether this helps *a lot* I can't say.  I've tried putting in the full URI
in a separate, colpanning row, but that sucks with :target, and I don't
see a solution of that.  One could consider playing games with mouse-following
URIs, but then for *us* the full URIs rarely matter, so they sholdn't
grab up too much attention and/or space.

Ah well.