### PR TITLE
Suppress recursiver narrower expansion for SKOS CSV, too.

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -390,7 +390,7 @@ def invert_wider(voc):
         for wider in term.get_objects_for(voc.wider_predicate):
             inverted_wider.setdefault(wider.lstrip("#"), []).append(t)
 
-    if voc.flavour!="SKOS":
+    if voc.flavour not in ["SKOS", "SKOS CSV"]:
         close_transitively(inverted_wider)
 
     return inverted_wider
@@ -653,8 +653,8 @@ class Term(object):
 
             if prop=="built-in:narrower":
                 objs = [self._format_term_as_html(t)
-                    for t in self.vocabulary.inverted_wider.get(
-                            self.term, [])]
+                    for t in sorted(self.vocabulary.inverted_wider.get(
+                            self.term, []))]
             else:
                 objs = [self._format_term_as_html(ob)
                     for ob in self.get_objects_for(prop)]


### PR DESCRIPTION
So far, we only skipped expansion of SKOS (RDF); I forgot to add to the suppression when I added the SKOS CSV flavour.  Which probably suggests this particular switch is not ideal.  Let's re-think that when we have another flavour with non-transitive broader.