### PR TITLE
SKOS vocabularies now produce URIs rather than literals for broader.

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -1112,9 +1112,11 @@ class SKOSVocabulary(SKOSMixin, Vocabulary):
         description = pick_exactly_one(self._get_skos_objects_for(voc,
             "http://www.w3.org/2004/02/skos/core#definition",
             term), "description for {}".format(term), "")
-        parents = list(self._get_skos_objects_for(voc,
-            "http://www.w3.org/2004/02/skos/core#broader",
-            term))
+        parents = list("#"+t
+            for t in self._get_skos_objects_for(
+                voc,
+                "http://www.w3.org/2004/02/skos/core#broader",
+                term))
 
         more_relations = []
 


### PR DESCRIPTION
This ought to fix Bug #19.