### PR TITLE
[DRAFT] Add skos topconcept

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,10 @@ Defining Vocabulary Metadata
 
 See Vocabularies in the VO 2, Appendix A.2.
 
+In addition to what's there, in 2024-03, we're prototyping a
+topconcepts key, which is a space-separated list of vocabulary terms
+that should become objects in (vocab, skos:hasTopConcept, .) triples.
+
 
 Deployment
 ==========

--- a/convert.py
+++ b/convert.py
@@ -121,6 +121,7 @@ dc:created a owl:AnnotationProperty.
 dc:creator a owl:AnnotationProperty.
 dc:title a owl:AnnotationProperty.
 dc:description a owl:AnnotationProperty.
+
 """
 
 
@@ -820,6 +821,8 @@ class Vocabulary(object):
       the vocabulary will not show up in the repo).
     * licensehtml: a human-readable license text that is reproduced
       verbatim in HTML.  Again, only use for externally managed vocabularies.
+    * topconcepts: space-separated identifiers that are declared as SKOS
+      top concepts.
 
     To derive a subclass, you need to define:
 
@@ -851,6 +854,7 @@ class Vocabulary(object):
             "licensehtml": DEFAULT_LICENSE_HTML,
             "licenseuri":
                 "http://creativecommons.org/publicdomain/zero/1.0/",
+            "topconcepts": "",
         }
         defaults.update(meta)
         meta = defaults
@@ -914,6 +918,9 @@ class Vocabulary(object):
                     '[ foaf:name {} ]'.format(make_ttl_literal(n.strip()))
                 for n in self.authors.split(";"))
             f.write(TTL_HEADER_TEMPLATE.format(**meta_items))
+
+            for top_concept in self.topconcepts.split():
+                f.write(f"<> skos:hasTopConcept <#{top_concept}>.\n")
 
             for _, term in sorted(self.terms.items()):
                 f.write(term.as_ttl())

--- a/convert.py
+++ b/convert.py
@@ -579,7 +579,7 @@ class Term(object):
 
     @staticmethod
     def _iter_relationship_literals(relations):
-        """yields paris of (predicate, object) for our relationship
+        """yields pairs of (predicate, object) for our relationship
         input format.
 
         That's a space-separated sequence of either predicate names or
@@ -632,12 +632,15 @@ class Term(object):
                             token_stack[-1] += arg
                         else:
                             # argument complete, reset parser
-                            yield predicate, arg
+                            yield predicate, arg[:-1]
                             predicate, token_stack = None, None
                     else:
                         # don't discard whitespace here
                         token_stack.append(mat.group())
 
+        if predicate:
+            # yield a singleton if you don't have yet
+            yield predicate, None
 
     def _parse_relations(self, relations):
         """adds relations passed in through the last column of our CSV.

--- a/product-type/terms.csv
+++ b/product-type/terms.csv
@@ -4,6 +4,7 @@ cube;2;Cube;A multidimensional astronomical image with 3 or more axes, e.g., a s
 spectral-cube;3;Spectral Cube;A 3-dimensional astronomical image with two spatial  and one spectral axis.;skos:broader(spatially-resolved-dataset) skos:broader(spectrally-resolved-dataset)
 time-cube;3;Time Cube;A 3-dimensional astronomical image with two spatial  and one temporal axis.;skos:broader(spatially-resolved-dataset) skos:broader(temporally-resolved-dataset)
 polarization-cube;3;Polarization Cube;A 3-dimensional astronomical image with two spatial  and one polarization axis.;skos:broader(spatially-resolved-dataset) skos:broader(polarization-resolved-dataset)
+spatial-profile;2;Spatial Profile;An observable obtained along a one-dimensional spatial path.;ivoasem:preliminary
 polarization-resolved-dataset;1;Polarization Resolved;Sets of fluxes for different polarization states.  This term is mainly intended for retrieval.  To annotate datasets, use a narrower term.
 spectrally-resolved-dataset;1;Spectrally Resolved;A dataset that has a spectral axis. This term is mainly intended for retrieval.  To annotate datasets, use a narrower term.
 spectrum;2;Spectrum;Flux or magnitude as a function of a spectral coordinate.

--- a/vocabs.conf
+++ b/vocabs.conf
@@ -22,7 +22,7 @@ authors: Plante, R.; Demleitner, M.
 [date_role]
 flavour: RDF Property
 path: voresource/date_role
-timestamp: 2022-04-22
+timestamp: 2024-03-22
 title: Roles of dates
 description: This vocabulary enumerates roles of dates in the evolution
 	of VO resources for use in VOResource's curation/date/@role attribute.

--- a/vocabs.conf
+++ b/vocabs.conf
@@ -94,7 +94,7 @@ authors: Demleitner, M.
 
 [uat]
 flavour:SKOS
-timestamp:2023-02-28
+timestamp:2024-03-25
 title: Unified Astronomy Thesaurus (IVOA rendering)
 description: This is a re-publication of the Unified Astronomy
 	Thesaurus (see https://astrothesaurus.org), in particular
@@ -108,6 +108,10 @@ licensehtml: This vocabulary, derived from the
 	<a href="https://creativecommons.org/licenses/by-sa/3.0/legalcode"
 	>CC-BY-SA</a>.
 licenseuri: https://creativecommons.org/licenses/by-sa/3.0/legalcode
+topconcepts: astronomical-methods observational-astronomy solar-physics
+  solar-system-astronomy stellar-astronomy cosmology exoplanet-astronomy
+  galactic-and-extragalactic-astronomy high-energy-astrophysics
+  interdisciplinary-astronomy interstellar-medium
 
 [product-type]
 flavour: SKOS CSV

--- a/vocabs.conf
+++ b/vocabs.conf
@@ -111,7 +111,7 @@ licenseuri: https://creativecommons.org/licenses/by-sa/3.0/legalcode
 
 [product-type]
 flavour: SKOS CSV
-timestamp:2023-06-26
+timestamp:2024-03-22
 title: Data Product Type
 description: This vocabulary gives a high level classification
 	for data products in astronomy.  It is derived from a word list used by

--- a/voresource/date_role/terms.csv
+++ b/voresource/date_role/terms.csv
@@ -13,3 +13,6 @@ Valid;1;Valid;A date of validitiy.  This is probably not useful in the VOResourc
 
 # VEP-013
 Inspected;1;Last Inspected;Dates with this role indicate when the resource has last undergone a non-formal inspection, typically by a human, as to whether it is still working as expectable, both technically and as regards its science content.
+
+# VEP-016
+ExportRequested;1;Export Requested;The date the publisher has requested non-VO bibliographic services to pick up and index the metadata of the resource as per the BibVO note.;ivoasem:preliminary


### PR DESCRIPTION
This is done through a new key in vocabs.conf; the alternative would
have been some trick to allow extra relationships in terms.csv with the
current term as object; but I think it's really preferable to add extra
"global" properties in vocabs.conf.

This will currently only work with SKOS vocabularies because the others
don't define the skos: prefix.  This would be simple to fix, but
currently I'm leaning towards rejecting topconcept for non-skos vocabularies

This commit also adds the top concepts of the UAT to have something to
play with.