### PR TITLE
Now adding onclick handlers to concept links.

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -706,7 +706,7 @@ class Term(object):
             term = term[1:]
 
         if term in self.vocabulary.terms:
-            return T.a(href="#"+term)[term]
+            return T.a(href="#"+term)
         else:
             return term
 
@@ -777,7 +777,9 @@ class Term(object):
         el =  T.tr(class_=row_class, id=self.term)[
             T.td(class_="term")[
                 T.a(title="Copy the link URL for this term's RDF URI",
-                    href=self.get_url())[self.term],
+                    href=self.get_url(),
+                    onclick=f"window.location.hash = '#{self.term}';"
+                        " return False")[self.term],
                 " (Preliminary)" if preliminary else "",
                 " (Deprecated)" if deprecated else ""],
             T.td(class_="label")[self.label],


### PR DESCRIPTION
This is to avoid going through redirects when people click on them. Ever since we give URLs as hrefs for the terms ("copy for the concept URI"), when someone clicked on them, there was a server roundtrip with all the redirects (because the URI the browser sees is the versioned URI, not the vocabulary URI).  There is little we can do about this in general (which is slightly regrettable because at least webkit browsers sometimes get confused with the fragments when they get the http->https upgrade redirects).  But when people have javascript on, we can avoid this; this is what this commit does.