### PR TITLE
Restoring labels in internal relationships.

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -443,7 +443,7 @@ class _Element(object):
                         self.node.attrib[k] = v
                 return self
 
-        def dump(self, encoding="utf-8", dest_file=sys.stdout):
+        def dump(self, encoding="utf-8", dest_file=sys.stdout.buffer):
             etree.ElementTree(self.node).write(
                 dest_file, encoding=encoding)
 
@@ -691,7 +691,7 @@ class Term(object):
             term = term[1:]
 
         if term in self.vocabulary.terms:
-            return T.a(href="#"+term)
+            return T.a(href="#"+term)["#"+term]
         else:
             return term
 

--- a/vocabs.conf
+++ b/vocabs.conf
@@ -169,6 +169,7 @@ description: A vocabulary giving identifiers, standard labels, and aliases
   “human-readable” strings for VODataService's facility elements, full
   vocabulary URIs into this vocabulary can be put into facility/@altIdentifier.
 draft: True
+hidden: True
 authors: Cecconi, B.
 
 [processing-level]


### PR DESCRIPTION
Also using the opportunity to hide the pre-draft facility vocabulary.  Sorry about the mixed-purpose commit, but this all seemed a bit lightweight for a PR in the first place.