### PR TITLE
JSON-LD output

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -74,6 +74,9 @@ RewriteRule ^{path}/?$ {path}/{timestamp}/{name}.rdf [R=303]
 RewriteCond %{{HTTP_ACCEPT}} text/turtle
 RewriteRule ^{path}/?$ {path}/{timestamp}/{name}.ttl [R=303]
 
+RewriteCond %{{HTTP_ACCEPT}} application/ld\\+json
+RewriteRule ^{path}/?$ {path}/{timestamp}/{name}.json [R=303]
+
 RewriteCond %{{HTTP_ACCEPT}} application/x-desise\\+json
 RewriteRule ^{path}/?$ {path}/{timestamp}/{name}.desise [R=303]
 

--- a/convert.py
+++ b/convert.py
@@ -1016,6 +1016,8 @@ class Vocabulary(object):
                     ", ",
                     T.a(href=self.name+".ttl")["Turtle"],
                     ", ",
+                    T.a(href=self.name+".json")["JSON-LD"],
+                    ", ",
                     T.a(href=self.name+".desise")["desise"],
                     " (non-RDF json)."],
                 license_element

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+rdflib
+skosify
+


### PR DESCRIPTION
Create a function to output vocabulary in JSON-LD format.
Externalize namespaces from TTL_HEADER_TEMPLATE to re-use them in the context parameter of serialize().

Rdflib's JSON-LD serializer does not support base URI. Hence, the JSON-LD output does not have a base prefix.
