### PR TITLE
add ucd-syntax-code term in ivoasem

### DIFF
--- a/ivoasem/terms.csv
+++ b/ivoasem/terms.csv
@@ -2,4 +2,4 @@ vocflavour;1;Vocabulary Flavour;The object of this property indicates what sorts
 preliminary;1;Preliminary;The subject of an RDF triple with this property is a term that is still under review and may disappear again.
 deprecated;1;Deprecated;The subject of an RDF triple with this property is a term that should no longer be used.
 useInstead;1;Replace with;Used in RDFs triples to indicate that the object should be used in new annotation where previously the subject was used.
-ucd-syntax-code;1;has UCD syntax code;UCD atoms canot be freely combined. Rather, each atom has a syntax code, which is one of p (only primary position), s (not in primary position), q (freely positionable), e (can be followed by a spectral atom), c (can be followed by two spectral atoms), or v (can be followed by a frame or axis atom).
+ucd-syntax-code;1;has UCD syntax code;UCD atoms canot be freely combined. Rather, each atom has a syntax code, which is one of p (only primary position), s (not in primary position), q (freely positionable), e (can be followed by a spectral atom), c (can be followed by two spectral atoms), or v (can be followed by a frame or axis atom).;ivoasem:preliminary

--- a/ivoasem/terms.csv
+++ b/ivoasem/terms.csv
@@ -1,4 +1,5 @@
 vocflavour;1;Vocabulary Flavour;The object of this property indicates what sorts of terms the vocabulary can contain.  See Vocabularies in the VO for the string literals allowed in objects of RDF triples using this.
 preliminary;1;Preliminary;The subject of an RDF triple with this property is a term that is still under review and may disappear again.
 deprecated;1;Deprecated;The subject of an RDF triple with this property is a term that should no longer be used.
-useInstead;1;Replace with;Used in RDFs triples to indicate that the object should be used in new annotation where previously the subject was used.;
+useInstead;1;Replace with;Used in RDFs triples to indicate that the object should be used in new annotation where previously the subject was used.
+ucd-syntax-code;1;has UCD syntax code;UCD atoms canot be freely combined. Rather, each atom has a syntax code, which is one of p (only primary position), s (not in primary position), q (freely positionable), e (can be followed by a spectral atom), c (can be followed by two spectral atoms), or v (can be followed by a frame or axis atom).

--- a/vocabs.conf
+++ b/vocabs.conf
@@ -85,7 +85,7 @@ authors: Dowler, P.; Gray, N.
 
 [ivoasem]
 flavour:RDF Property
-timestamp: 2021-06-08
+timestamp: 2026-01-15
 title: IVOA Semantics
 description: This vocabulary defines several properties used in the
   management of IVOA vocabularies.  Their use and purpose is explained


### PR DESCRIPTION
As proposed in [VEP_O19](https://github.com/ivoa-std/VEPs/blob/main/VEP-019.txt), I add the term ucd-syntax-code in ivoasem vocabulary. 
