### PR TITLE
Un-hiding obsfacility, fixing product-type date

### DIFF
--- a/vocabs.conf
+++ b/vocabs.conf
@@ -115,7 +115,7 @@ topconcepts: astronomical-methods observational-astronomy solar-physics
 
 [product-type]
 flavour: SKOS CSV
-timestamp:2024-05-19
+timestamp: 2026-01-15
 title: Data Product Type
 description: This vocabulary gives a high level classification
 	for data products in astronomy.  It is derived from a word list used by
@@ -165,7 +165,6 @@ title: Observations Facilities
 description: A vocabulary giving identifiers, standard labels, and aliases
   for observatories, space probes, telescopes and alike.
 draft: True
-hidden: False
 authors: Cecconi, B.; Fretel, L.; Debisschop, L.
 
 [processing-level]


### PR DESCRIPTION
The product-type date is the one that was actually used for installation.